### PR TITLE
Add schematic to set up global error handling in a project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,52 @@
         "rxjs": "6.6.7"
       }
     },
+    "@angular/cdk": {
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-12.0.4.tgz",
+      "integrity": "sha512-NX/1kEc6ndyEHjGcMtMJYEjwmoURuwRSqKJLbGcHTUwXuuR+hfDP/vU1XDOeXNC80SV+0B4BpJnREkINILfYKw==",
+      "requires": {
+        "parse5": "^5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@angular/common": {
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.0.4.tgz",
+      "integrity": "sha512-P0l5OcDdJhsURakJXxV9tGbicY8a6fEBsB+9f4iTEm36Q1FO0/7RhMMlwUDBlNK37P1oi7pEUA0mRcFIx9TOLA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@angular/core": {
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.0.4.tgz",
+      "integrity": "sha512-KYFcFDot89F65CN3MzMEFoUPCVEZUkSQCLyxWfJAJT56Vtik6r91w6qwprFJ2wRk7SJ7018NLFwjZQIElj0s8A==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
     "@schematics/angular": {
       "version": "12.0.4",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-12.0.4.tgz",
@@ -517,6 +563,12 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "optional": true
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -838,6 +890,21 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "zone.js": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz",
+      "integrity": "sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,14 @@
   "dependencies": {
     "@angular-devkit/core": "^12.0.4",
     "@angular-devkit/schematics": "^12.0.4",
+    "@angular/cdk": "^12.0.4",
+    "@angular/common": "^12.0.4",
+    "@angular/core": "^12.0.4",
     "@schematics/angular": "^12.0.4",
     "@types/lodash": "^4.14.161",
     "lodash": "^4.17.20",
-    "typescript": "~4.1.5"
+    "typescript": "~4.1.5",
+    "zone.js": "^0.11.4"
   },
   "devDependencies": {
     "@types/node": "^12.11.1",

--- a/src/collection.json
+++ b/src/collection.json
@@ -25,6 +25,12 @@
       "factory": "./library",
       "schema": "./library/schema.json",
       "description": "Generate a library project for Angular."
+    },
+    "global-error-handling": {
+      "aliases": ["geh"],
+      "factory": "./ng-generate/global-error-handling",
+      "schema": "./ng-generate/global-error-handling/schema.json",
+      "description": "Adds global error handling to the project"
     }
   }
 }

--- a/src/ng-generate/global-error-handling/defaults.ts
+++ b/src/ng-generate/global-error-handling/defaults.ts
@@ -1,0 +1,26 @@
+import { ProjectDefinition, WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
+
+import { GenerateGlobalErrorHandlingSchema } from './schema';
+
+/**
+ * Updates the `project` schematic option to the name of the default project if it's undefined.
+ * @param options The options for running the schematic.
+ * @param workspace The definition of the current workspace.
+ */
+export const fallBackToDefaultProjectName = (options: GenerateGlobalErrorHandlingSchema, workspace: WorkspaceDefinition): void => {
+    if (options.project === undefined) {
+        options.project = workspace.extensions.defaultProject as string;
+    }
+};
+
+/**
+ * Updates the `path` schematic option to the combination of project source root and project type if it's undefined.
+ * @param options The options for running the schematic.
+ * @param project The definition of the project to execute the schematic on.
+ * @param projectType The type of the project to execute the schematic on.
+ */
+export const fallBackToDefaultPath = (options: GenerateGlobalErrorHandlingSchema, project: ProjectDefinition, projectType: string): void => {
+    if (options.path === undefined) {
+        options.path = `${project.sourceRoot}/${projectType}`;
+    }
+};

--- a/src/ng-generate/global-error-handling/files.ts
+++ b/src/ng-generate/global-error-handling/files.ts
@@ -1,0 +1,20 @@
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import * as ts from 'typescript';
+
+/**
+ * Gets a TypeScript SourceFile for the given path in the given tree.
+ * @param host The host tree to look in.
+ * @param path The path to the file in the tree to look for.
+ * @throws a SchematicsException if the file could not be read.
+ * @returns A TypeScript SourceFile instance representing the file.
+ */
+export const getTsSourceFile = (host: Tree, path: string): ts.SourceFile => {
+    const buffer = host.read(path);
+    if (!buffer) {
+        throw new SchematicsException(`Could not read file (${path}).`);
+    }
+
+    const content = buffer.toString();
+    
+    return ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true);
+};

--- a/src/ng-generate/global-error-handling/files/global-error-handling/__name@dasherize__.ts.template
+++ b/src/ng-generate/global-error-handling/files/global-error-handling/__name@dasherize__.ts.template
@@ -1,0 +1,11 @@
+import { ErrorHandler, Injectable } from '@angular/core';
+
+/**
+ * Handle any errors thrown by Angular application.
+ */
+ @Injectable()
+ export class <%= classify(name) %> extends ErrorHandler {
+   handleError(error: any): void {
+     super.handleError(error);
+   }
+ }

--- a/src/ng-generate/global-error-handling/files/global-error-handling/global-error-handling.module.ts.template
+++ b/src/ng-generate/global-error-handling/files/global-error-handling/global-error-handling.module.ts.template
@@ -1,0 +1,13 @@
+import { ErrorHandler, ModuleWithProviders, NgModule, Type } from '@angular/core';
+
+@NgModule()
+export class GlobalErrorHandlingModule {
+  static forRoot<T extends ErrorHandler>(handlerType: Type<T>): ModuleWithProviders<GlobalErrorHandlingModule> {
+    return {
+      ngModule: GlobalErrorHandlingModule,
+      providers: [
+        { provide: ErrorHandler, useClass: handlerType }
+      ]
+    };
+  }
+}

--- a/src/ng-generate/global-error-handling/index.spec.ts
+++ b/src/ng-generate/global-error-handling/index.spec.ts
@@ -1,0 +1,60 @@
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+
+import { ApplicationOptions } from '../../application';
+import { GenerateGlobalErrorHandlingSchema } from './schema';
+
+describe('Global Error Handling schematic', () => {
+    const schematicRunner = new SchematicTestRunner(
+        'ppwcode-angular-schematics',
+        require.resolve('../../collection.json'),
+    );
+
+    const workspaceOptions = {
+        name: 'workspace',
+        newProjectRoot: 'projects',
+        version: '6.0.0',
+    };
+
+    const applicationOptions: ApplicationOptions = {
+        name: 'foo',
+        routing: undefined,
+        style: undefined,
+        prefix: 'foo',
+    };
+
+    const defaultOptions: GenerateGlobalErrorHandlingSchema = {
+        path: '/projects/foo/src/app',
+        name: 'app-error-handler',
+        project: 'foo'
+    };
+
+    let workspaceTree: UnitTestTree;
+    beforeEach(async () => {
+        workspaceTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
+        workspaceTree = await schematicRunner.runSchematicAsync('application', applicationOptions, workspaceTree).toPromise();
+    });
+
+    it('should generate the files', async () => {
+        const options = { ...defaultOptions };
+
+        const tree = await schematicRunner.runSchematicAsync('global-error-handling', options, workspaceTree)
+            .toPromise();
+        const files = tree.files;
+        expect(files).toContain('/projects/foo/src/app/global-error-handling/global-error-handling.module.ts');
+        expect(files).toContain('/projects/foo/src/app/global-error-handling/app-error-handler.ts');
+    });
+
+    it('should import in the app module', async () => {
+        const options = { ...defaultOptions };
+
+        const tree = await schematicRunner.runSchematicAsync('global-error-handling', options, workspaceTree)
+            .toPromise();
+        const moduleContent = tree.readContent('/projects/foo/src/app/app.module.ts');
+
+        // Expect the import statement at the top.
+        expect(moduleContent).toMatch(/import.*AppErrorHandler.*from '.\/global-error-handling\/app-error-handler'/);
+        
+        // Expect the forRoot call with AppErrorHander in the imports of the NgModule.
+        expect(moduleContent).toMatch(/imports:\s*\[[^\]]+?,\r?\n\s+GlobalErrorHandlingModule.forRoot\(AppErrorHandler\)\r?\n/m);
+    });
+});

--- a/src/ng-generate/global-error-handling/index.ts
+++ b/src/ng-generate/global-error-handling/index.ts
@@ -1,0 +1,25 @@
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { findModuleFromOptions } from '@angular/cdk/schematics';
+import { getWorkspace } from '@schematics/angular/utility/workspace';
+
+import { fallBackToDefaultPath } from './defaults';
+import { getProject } from './project';
+import { addModuleImports, createFilesIfTheyDontExistYet } from './rules';
+import { GenerateGlobalErrorHandlingSchema } from './schema';
+
+
+export default function (options: GenerateGlobalErrorHandlingSchema): Rule {
+    return async (host: Tree) => {
+        const workspace = await getWorkspace(host);
+
+        const { project, projectType } = getProject(options, workspace);
+        fallBackToDefaultPath(options, project, projectType);
+
+        const modulePath = (await findModuleFromOptions(host, options))!;
+
+        return chain([
+            createFilesIfTheyDontExistYet(options),
+            addModuleImports(host, modulePath, options)
+        ]);
+    };
+}

--- a/src/ng-generate/global-error-handling/project.ts
+++ b/src/ng-generate/global-error-handling/project.ts
@@ -1,0 +1,32 @@
+import { ProjectDefinition, WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
+import { SchematicsException } from '@angular-devkit/schematics';
+
+import { fallBackToDefaultProjectName } from './defaults';
+import { GenerateGlobalErrorHandlingSchema } from './schema';
+
+/**
+ * Gets the definition of a project and its related type. If no project name is explicitly given, we fall back to the
+ * default project.
+ * @param options The options for running the schematic.
+ * @param workspace The current workspace definition.
+ * @throws a SchematicsException if the project name is undefined.
+ * @throws a SchematicsException if the project could not be found in the workspace.
+ * @returns The project definition and its related type.
+ */
+export const getProject = (options: GenerateGlobalErrorHandlingSchema, workspace: WorkspaceDefinition): { project: ProjectDefinition, projectType: string } => {
+    fallBackToDefaultProjectName(options, workspace);
+
+    if (options.project === undefined) {
+        throw new SchematicsException(`Invalid project name: ${options.project}`);
+    }
+
+    const project = workspace.projects.get(options.project);
+    if (project === undefined) {
+        throw new SchematicsException(`Project ${options.project} not found in the workspace`);
+    }
+
+    return {
+        project,
+        projectType: project.extensions.projectType === 'application' ? 'app' : 'lib'
+    };
+};

--- a/src/ng-generate/global-error-handling/rules.ts
+++ b/src/ng-generate/global-error-handling/rules.ts
@@ -1,0 +1,72 @@
+import { classify, dasherize } from '@angular-devkit/core/src/utils/strings';
+import {
+    apply,
+    applyTemplates,
+    MergeStrategy,
+    mergeWith,
+    move,
+    Rule,
+    SchematicsException,
+    Tree,
+    url,
+} from '@angular-devkit/schematics';
+import { addModuleImportToModule, insertImport } from '@angular/cdk/schematics';
+import { InsertChange } from '@schematics/angular/utility/change';
+
+import { getTsSourceFile } from './files';
+import { GenerateGlobalErrorHandlingSchema } from './schema';
+
+/**
+ * Generates a Rule that will create the files based on the templates and move them to
+ * the path that has been set on the schematic options.
+ * @param options The options for running the schematic.
+ * @throws a SchematicsException if the name of the generated class will be ErrorHandler.
+ * @returns A rule to be chained.
+ */
+export const createFilesIfTheyDontExistYet = (options: GenerateGlobalErrorHandlingSchema): Rule => {
+    if (classify(options.name) === 'ErrorHandler') {
+        throw new SchematicsException('This would generate a class with the name ErrorHandler, which conflicts with the interface exported by Angular.');
+    }
+
+    return mergeWith(
+        apply(url('./files'), [
+            applyTemplates({
+                dasherize,
+                classify,
+                name: options.name,
+            }),
+            move(options.path),
+        ]), MergeStrategy.AllowCreationConflict);
+};
+
+/**
+ * Generates a rule that will add the global error handling module to the given module file and imports the error handler
+ * to the module file as well.
+ * 
+ * The error handler will be passed as the first argument to the global error handling module that is imported.
+ * @param host The host tree structure.
+ * @param modulePath The path of the module file.
+ * @param options The options for running the schematic.
+ * @returns A rule to be chained.
+ */
+export const addModuleImports = (host: Tree, modulePath: string, options: GenerateGlobalErrorHandlingSchema): Rule => {
+    return () => {
+        addModuleImportToModule(
+            host,
+            modulePath,
+            `GlobalErrorHandlingModule.forRoot(${classify(options.name)})`,
+            './global-error-handling/global-error-handling.module'
+        );
+
+        const moduleFile = getTsSourceFile(host, modulePath);
+
+        // Update the module file to add an import statement for the error displayer.
+        const updateRecorder = host.beginUpdate(modulePath);
+        const change = insertImport(moduleFile, modulePath, classify(options.name), `./global-error-handling/${dasherize(options.name)}`);
+        if (change instanceof InsertChange) {
+            updateRecorder.insertRight(change.pos, change.toAdd);
+        }
+
+        host.commitUpdate(updateRecorder);
+    };
+};

--- a/src/ng-generate/global-error-handling/schema.json
+++ b/src/ng-generate/global-error-handling/schema.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/schema",
+    "$id": "GenerateGlobalErrorHandling",
+    "title": "Generate Global Error Handling",
+    "description": "Generates a class that extends the Angular ErrorHandler class and a module. Updates the project module to import the generated module so that error handling is set up.",
+    "type": "object",
+    "properties": {
+        "name": {
+            "description": "The name of error displayer class.",
+            "type": "string",
+            "$default": {
+                "$source": "argv",
+                "index": 0
+            },
+            "x-prompt": "What name would you like to use for the error displayer class?"
+        },
+        "project": {
+            "type": "string",
+            "description": "The name of the project.",
+            "$default": {
+                "$source": "projectName"
+            }
+        }
+    }
+}

--- a/src/ng-generate/global-error-handling/schema.ts
+++ b/src/ng-generate/global-error-handling/schema.ts
@@ -1,0 +1,10 @@
+export interface GenerateGlobalErrorHandlingSchema {
+    // The name of the error handler class.
+    name: string;
+
+    // The path to generate the files.
+    path: string;
+
+    // The name of the project.
+    project: string;
+}


### PR DESCRIPTION
Schematic will generate a module and a handler class. The generated module will be imported in the app module.